### PR TITLE
fix the RGB order bug in demo.py

### DIFF
--- a/sixdrepnet/demo.py
+++ b/sixdrepnet/demo.py
@@ -114,8 +114,7 @@ if __name__ == '__main__':
                 y_max = y_max+int(0.2*bbox_width)
 
                 img = frame[y_min:y_max, x_min:x_max]
-                img = Image.fromarray(img)
-                img = img.convert('RGB')
+                img = Image.fromarray(img[...,::-1])
                 img = transformations(img)
 
                 img = torch.Tensor(img[None, :]).to(device)

--- a/sixdrepnet/demo.py
+++ b/sixdrepnet/demo.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
         while True:
             ret, frame = cap.read()
 
-            faces = detector(frame)
+            faces = detector(frame, cv=True) # set cv to True for bgr input, the default value of cv is False
 
             for box, landmarks, score in faces:
 


### PR DESCRIPTION
The previous implementation does not actually convert the image to RGB, as `Image.from_array` assumes RGB input